### PR TITLE
Issue #28: Bump required "catalog" version to 0.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "~7.0.0",
         "ext-imagick": "*",
-        "lizards-and-pumpkins/catalog": "~0.17.0"
+        "lizards-and-pumpkins/catalog": "~0.18.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Closes #28.